### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-ant.design


### PR DESCRIPTION
Hello @ingf, we are moving https://ant.design to GitHub Pages, according to the [document](https://help.github.com/en/articles/troubleshooting-custom-domains#cname-already-taken), could you please remove the CNAME file in this repo? Thanks!